### PR TITLE
Set precision correctly on full date time strings.

### DIFF
--- a/src/date.js
+++ b/src/date.js
@@ -88,7 +88,7 @@ class Date extends global.Date {
 
 
   set precision(value) {
-    P.set(this, Number(value))
+    P.set(this, (value > 3) ? 0 : Number(value));
   }
 
   get precision() {
@@ -225,7 +225,7 @@ class Date extends global.Date {
   }
 
   toEDTF() {
-    if (!this.precision || this.precision > 3) return this.toISOString()
+    if (!this.precision) return this.toISOString()
 
     let values = this.values.map(Date.pad)
 

--- a/src/date.js
+++ b/src/date.js
@@ -88,7 +88,7 @@ class Date extends global.Date {
 
 
   set precision(value) {
-    P.set(this, Number(value) % 4)
+    P.set(this, Number(value))
   }
 
   get precision() {
@@ -225,7 +225,7 @@ class Date extends global.Date {
   }
 
   toEDTF() {
-    if (!this.precision) return this.toISOString()
+    if (!this.precision || this.precision > 3) return this.toISOString()
 
     let values = this.values.map(Date.pad)
 

--- a/test/date.js
+++ b/test/date.js
@@ -27,6 +27,24 @@ describe('Date', () => {
     })
   })
 
+  describe('.precision', () => {
+    it('YYYY', () => {
+      expect(new Date([1980]).precision).to.eql(1)
+    })
+
+    it('YYYY-MM', () => {
+      expect(new Date([1980, 1]).precision).to.eql(2)
+    })
+
+    it('YYYY-MM-DD', () => {
+      expect(new Date([1980, 1, 23]).precision).to.eql(3)
+    })
+
+    it('YYYY-MM-DDThh:mm:ss', () => {
+      expect(new Date([1980, 1, 12, 10, 15, 30]).precision).to.eql(6)
+    })
+  })
+
   describe('.next()', () => {
     it('YYYY', () => {
       expect(new Date([1980]).next().edtf).to.eql('1981')


### PR DESCRIPTION
Full ISO strings including times currently cause the precision to be set as if only year-month was provided.

The parser is parsing it fine, and the underlying native date object is set correctly:

```
> edtf.parse('2001-02-03T10:10:10')
{ values: [ 2001, 1, 3, 10, 10, 10 ],
  offset: null,
  type: 'Date',
  level: 0 }
> edtf('2001-02-03T10:10:10').toISOString()
'2001-02-03T10:10:10.000Z'
```

It's just the `precision` thats off:
```
> edtf('2001-02-03T10:10:10').precision
2
```

This has a knock on effect on a whole bunch of stuff, including truncating what you get back from the `values` getter, and messes up any calls to `next()`, `previous()`, `max`, `toEDTF()` etc etc.

The issue seems to be the modulo in the [precision setter](https://github.com/inukshuk/edtf.js/blob/master/src/date.js#L91):
```js
  set precision(value) {
    P.set(this, Number(value) % 4) // This would explain it? 6 % 4 == 2
  }
```
I don't entirely know what I'm doing here, but this pull request removes it, which allows the precision to be 6 in this case. It then also fixes up the `toEDTF()` method to handle this new eventuality. 

All the existing tests still pass, along with a new one to check the precision gets set right.

Let me know if I've gone about this all wrong!