### PR TITLE
Add support for century zero

### DIFF
--- a/src/century.js
+++ b/src/century.js
@@ -57,16 +57,26 @@ class Century extends ExtDateTime {
 
   set century(century) {
     century = floor(Number(century))
-    assert(century !== 0 && abs(century) < 100, `invalid century: ${century}`)
+    assert(abs(century) < 100, `invalid century: ${century}`)
     return this.values[0] = century
   }
 
   get year() {
-    return this.values[0] * 100
+    if (this.values[0] >= 0) {
+      return this.values[0] * 100
+    }
+    else {
+      return this.values[0] * 100 + 1
+    }
   }
 
   set year(year) {
-    return this.century = year / 100
+    if (year >= 0) {
+      return this.century = year / 100
+    }
+    else {
+      return this.century = (year - 1) / 100
+    }
   }
 
   get values() {
@@ -78,7 +88,13 @@ class Century extends ExtDateTime {
   }
 
   get max() {
-    return ExtDate.UTC(this.year + 100, 0) - 1
+    if (this.century == -1) {
+      return ExtDate.UTC(this.year + 99, 0) - 1
+    }
+    else {
+      return ExtDate.UTC(this.year + 100, 0) - 1
+    }
+
   }
 
   toEDTF() {

--- a/src/century.js
+++ b/src/century.js
@@ -64,8 +64,7 @@ class Century extends ExtDateTime {
   get year() {
     if (this.values[0] >= 0) {
       return this.values[0] * 100
-    }
-    else {
+    } else {
       return this.values[0] * 100 + 1
     }
   }
@@ -73,8 +72,7 @@ class Century extends ExtDateTime {
   set year(year) {
     if (year >= 0) {
       return this.century = year / 100
-    }
-    else {
+    } else {
       return this.century = (year - 1) / 100
     }
   }
@@ -88,10 +86,9 @@ class Century extends ExtDateTime {
   }
 
   get max() {
-    if (this.century == -1) {
+    if (this.century === -1) {
       return ExtDate.UTC(this.year + 99, 0) - 1
-    }
-    else {
+    } else {
       return ExtDate.UTC(this.year + 100, 0) - 1
     }
 

--- a/src/edtf.ne
+++ b/src/edtf.ne
@@ -29,6 +29,7 @@ L0 -> date_time {% id %}
 L0i -> date_time "/" date_time {% interval(0) %}
 
 century -> positive_century     {% data => century(data[0]) %}
+         | "00"                 {% () => century(0) %}
          | "-" positive_century {% data => century(-data[1]) %}
 
 positive_century -> positive_digit digit {% num %}

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -21,6 +21,8 @@ var grammar = {
     {"name": "L0", "symbols": ["L0i"], "postprocess": id},
     {"name": "L0i", "symbols": ["date_time", {"literal":"/"}, "date_time"], "postprocess": interval(0)},
     {"name": "century", "symbols": ["positive_century"], "postprocess": data => century(data[0])},
+    {"name": "century$string$1", "symbols": [{"literal":"0"}, {"literal":"0"}], "postprocess": function joiner(d) {return d.join('');}},
+    {"name": "century", "symbols": ["century$string$1"], "postprocess": () => century(0)},
     {"name": "century", "symbols": [{"literal":"-"}, "positive_century"], "postprocess": data => century(-data[1])},
     {"name": "positive_century", "symbols": ["positive_digit", "digit"], "postprocess": num},
     {"name": "positive_century", "symbols": [{"literal":"0"}, "positive_digit"], "postprocess": num},


### PR DESCRIPTION
Right, let me be clear, I think that this is a hack, and probably shouldn't be merged.

This is an attempt to help out with #2.

I have noticed that the concept of Century in this library doesn't match with the 'English' concept of Century.

For example, I would say to someone: "This happened in the 20th Century" and I would mean that it happened at some point in the year range: `1900-1999`

However, the edtf.js library Century 20, i.e. `edtf.Century(20)` covers the period: `2000-2099`.
But, creating `Century(0)` isn't allowed by the library.

I'm looking to 'solve' the issue where I need to find the min/max of dates like `01XX` and `00XX`. Note that as per #2 this currently doesn't work, but if I just remove the 'XX' on the end of the years, it does.

`01XX` is converted to `01` and then min/max work correctly.

However, `00XX` is converted to `00` which is then invalid :(

So, this PR allows creating `Century(0)` and also cleans up the handling of negative centuries, as the year/min/max was wrong there.