### PR TITLE
Unspecified leap years

### DIFF
--- a/src/bitmask.js
+++ b/src/bitmask.js
@@ -9,7 +9,7 @@ const PATTERN = /^[0-9xXdDmMyY]{8}$/
 const YYYYMMDD = 'YYYYMMDD'.split('')
 const MAXDAYS = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
 
-const { floor, pow, max, min } = Math
+const { floor, pow, max, min, abs } = Math
 
 
 /**
@@ -173,6 +173,9 @@ class Bitmask {
       }
 
       break
+    default:
+      if (!this.test(Bitmask.MONTH) && month === 1 && day === 29)
+        year = this.lastLeapYear(year)
     }
 
     if (month === 1 && day > 28 && !leap(year)) {
@@ -263,6 +266,24 @@ class Bitmask {
   toString(symbol = 'X') {
     return this.masks(['YYYY', 'MM', 'DD'], symbol).join('-')
   }
+
+  lastLeapYear(year) {
+    if (leap(year))
+      return year
+    const values = [pad(year)]
+    const [minYear] = this.min(values)
+    const yearReg = this.masks(values, '.')
+    let [newYear] = this.max(values)
+
+    while (!(leap(newYear) &&
+            pad(newYear).match(yearReg)) &&
+            newYear >= minYear) {
+      newYear--
+    }
+    if (newYear < minYear)
+      return year
+    return newYear
+  }
 }
 
 Bitmask.prototype.is = Bitmask.prototype.test
@@ -272,6 +293,16 @@ function leap(year) {
   if (year % 100 > 0) return true
   if (year % 400 > 0) return false
   return true
+}
+
+function pad(number) {
+  let k = abs(number)
+
+  if (k < 10)   return `000${k}`
+  if (k < 100)  return `00${k}`
+  if (k < 1000) return `0${k}`
+
+  return `${k}`
 }
 
 Bitmask.DAY   = Bitmask.D = Bitmask.compute('yyyymmxx')

--- a/src/date.js
+++ b/src/date.js
@@ -61,7 +61,26 @@ class Date extends global.Date {
               args[4] = args[4] + obj.offset
             }
 
-            args = [ExtDateTime.UTC(...args)]
+            let UTCDateTime = ExtDateTime.UTC(...args)
+
+            const mask = new Bitmask(obj.unspecified)
+            if (mask.test(Bitmask.YEAR) > 0 &&
+            !mask.test(Bitmask.MONTH) &&
+            !mask.test(Bitmask.DAY)) {
+              let date = new global.Date(UTCDateTime),
+                year = date.getUTCFullYear(),
+                day = date.getUTCDate()
+              const leapYear = mask.lastLeapYear(abs(year))
+              if (leapYear !== abs(year)) {
+                args[0] = leapYear * (year < 0 ? -1 : 1)
+                let newUTCDateTime = ExtDateTime.UTC(...args),
+                  newDate = new global.Date(newUTCDateTime),
+                  newDay = newDate.getUTCDate()
+                if (newDay !== day) UTCDateTime = newUTCDateTime
+              }
+            }
+
+            args = [UTCDateTime]
           }
 
           ({ uncertain, approximate, unspecified } = obj)

--- a/test/date.js
+++ b/test/date.js
@@ -588,3 +588,28 @@ describe('Date', () => {
       expect(new Date([2014, 3, 1]).format('en-US')).to.eql('4/1/2014'))
   })
 })
+
+describe('Leap year', () => {
+  it('YYXX-02-29', () => {
+    let date = new Date({
+      values: [2100, 1, 29],
+      unspecified: 12
+    })
+
+    expect(date.edtf).to.eql('21XX-02-29')
+
+    date = new Date('21XX-02-29')
+
+    expect(date.edtf).to.eql('21XX-02-29')
+  })
+
+  it('.next()', () => {
+    let date = new Date('201X-02-28')
+    expect(date.next().edtf).to.eql('201X-02-29')
+  })
+
+  it('.prev()', () => {
+    let date = new Date('201X-03-01')
+    expect(date.prev().edtf).to.eql('201X-02-29')
+  })
+})


### PR DESCRIPTION
Here is my first suggestion draft to tackle issue #20 . All previous tests pass without any issues so it does not seem to be too breaking.

### What it does

I tried to limit the changes to only alter the code's behavior in the specific situations where it would have confusing results. (ie. to change the `year` value **only** when necessary to fit the EDTF pattern) This implied 2 changes

#### 1st change: in the Bitmask element

- I created a `lastLeapYear(year)` instance method to the `Bitmask` object: given the object's value and its `year` parameter containing a given year (in the form of a positive `Number`), the method will return the biggest leap year that can match the combination of these 2. If there is no match **or** if the given year is *already* a leap year, the method will return the given year.

- In the `max` method, when the month and day are fully specified and correspond to February 29th, we make use of that `lastLeapYear` method above to replace the year that we will return with the biggest leap year instead. This change avoids erroneously moving the `day` back to 28 in the next line in the case of an unspecified year that matches leap years.

#### 2nd change: in the Date element

Any time a new `edtf.Date` is created, after parsing and generating the desired UTC date like before:

1. We check if the year is unspecified but the month and day are specified
2. If not, fall back to the usual behavior. Else, we check (using our `lastLeapYear` created above) if any leap year matches the `year` and `unspecified` Bitmask that were given as arguments
3. If not, fall back to usual behavior. Else, we replace the year from the original `args` with the top leap year (or bottom leap year if BC) possible in the interval given by the `unspecified` Bitmask, and create a new UTC date
4. If the `date` value from the newly created date differs from the one in the original date, it means the leap year matters in this, so we use this newly created date instead of the original one.

### Possible issues with this draft fix

- `Bitmask` reuses a part of `Date.pad` to convert years to string in the `lastLeapyear` method. We should find a way to combine this bit. Unfortunately, the `utils.js` file depends from `bitmask.js`, so it couldn't fit there...

- Some of the conditions may feel a little complex, which may be due to a lack of understanding of the tooling in my disposition. Some of the code can probably be easily refactored to read much nicer than it currently does.

- Maybe this fix adds too much complexity? I stumbled a lot before coming to this acceptable answer, I could not see a better way to fix issue #20 while having the least impact on the rest of the library.