### PR TITLE
Fix-parse-unknown-start-to-1969-interval

### DIFF
--- a/src/interval.js
+++ b/src/interval.js
@@ -90,7 +90,7 @@ export class Interval extends ExtDateTime {
 
     value = getDateOrSeasonFrom(value)
 
-    if (this.lower !== Infinity && value <= this.lower)
+    if (this.lower !== Infinity && value <= this.lower && this.lower != null)
       throw new RangeError(`invalid upper bound: ${value}`)
 
     this.values[1] =  value

--- a/test/edtf.js
+++ b/test/edtf.js
@@ -21,6 +21,8 @@ describe('edtf', () => {
     expect(edtf('[2016-03]')).to.be.instanceof(Set)
     expect(edtf('{2016..2020}')).to.be.instanceof(List)
     expect(edtf('2016/2019')).to.be.instanceof(Interval)
+    expect(edtf('/1970-01-02')).to.be.instanceof(Interval)
+    expect(edtf('/1969')).to.be.instanceof(Interval)
     expect(edtf('2016-21')).to.be.instanceof(Season)
     expect(edtf('Y210001')).to.be.instanceof(Year)
   })


### PR DESCRIPTION
Fix for intervals with unknown start end and end before 1970-01-01.