### PR TITLE
Add basic TypeScript declaration files (first pass)

### DIFF
--- a/src/assert.d.ts
+++ b/src/assert.d.ts
@@ -1,0 +1,6 @@
+export declare function assert(value: any, message?: string): boolean;
+export declare namespace assert {
+    var equal: typeof import("./assert").equal;
+}
+export declare function equal<T>(actual: T, expected: T, message?: string): boolean;
+export default assert;

--- a/src/bitmask.d.ts
+++ b/src/bitmask.d.ts
@@ -1,0 +1,57 @@
+/**
+ * Bitmasks are used to set Unspecified, Uncertain and
+ * Approximate flags for a Date. The bitmask for one
+ * feature corresponds to a numeric value based on the
+ * following pattern:
+ *
+ *           YYYYMMDD
+ *           --------
+ *   Day     00000011
+ *   Month   00001100
+ *   Year    11110000
+ *
+ */
+export declare class Bitmask {
+    value: number;
+    static YEAR: number;
+    static Y: number;
+    static MONTH: number;
+    static M: number;
+    static DAY: number;
+    static D: number;
+    static MD: number;
+    static YMD: number;
+    static YM: number;
+    static YYXX: number;
+    static YYYX: number;
+    static XXXX: number;
+    static DX: number;
+    static XD: number;
+    static MX: number;
+    static XM: number;
+    static UA: [number, number, number, number, number, number];
+    static test(a: Bitmask | number | boolean | string, b: Bitmask | number | boolean | string): number;
+    static convert(value?: Bitmask | number | boolean | string): number;
+    static compute(value: string): number;
+    static values(mask: string, digit?: number): number[];
+    static numbers(mask: string, digit?: number): string;
+    static normalize(values: number[]): number[];
+    constructor(value?: number);
+    test(value?: number): number;
+    is: (value?: number) => number;
+    bit(k: number): number;
+    get day(): number;
+    get month(): number;
+    get year(): number;
+    add(value: string | number | boolean | Bitmask): this;
+    set(value?: string | number | boolean | Bitmask): this;
+    mask(input?: string[], offset?: number, symbol?: string): string[];
+    masks(values: string[], symbol?: string): string[];
+    max([year, month, day]: [number, number, number]): number[];
+    min([year, month, day]: [number, number, number]): number[];
+    marks(values: any, symbol?: string): any;
+    qualified(idx: number): boolean;
+    qualify(idx: number): this;
+    toJSON(): number;
+    toString(symbol?: string): string;
+}

--- a/src/century.d.ts
+++ b/src/century.d.ts
@@ -1,0 +1,13 @@
+import { ExtDateTime } from './interface.js';
+export declare class Century extends ExtDateTime {
+    constructor(input: any);
+    get century(): any;
+    set century(century: any);
+    get year(): number;
+    set year(year: number);
+    get values(): any;
+    get min(): number;
+    get max(): number;
+    toEDTF(): string;
+    static pad(number: any): string;
+}

--- a/src/date.d.ts
+++ b/src/date.d.ts
@@ -1,0 +1,36 @@
+import { Bitmask } from "./bitmask.js";
+import { ParserResult } from "./parser.js";
+export declare class Date extends globalThis.Date {
+    constructor(...args: ConstructorParameters<typeof globalThis.Date> | Partial<ParserResult>[]);
+    set precision(value: number);
+    get precision(): number;
+    set uncertain(value: boolean);
+    get uncertain(): boolean;
+    set approximate(value: number);
+    get approximate(): number;
+    set unspecified(value: number);
+    get unspecified(): number;
+    get atomic(): boolean;
+    get min(): number;
+    get max(): number;
+    get year(): number;
+    get month(): number;
+    get date(): number;
+    get hours(): number;
+    get minutes(): number;
+    get seconds(): number;
+    get values(): number[];
+    /**
+     * Returns the next second, day, month, or year, depending on
+     * the current date's precision. Uncertain, approximate and
+     * unspecified masks are copied.
+     */
+    next(k?: number): Date;
+    prev(k?: number): Date;
+    [Symbol.iterator](): Generator<this, void, unknown>;
+    toEDTF(): string;
+    format(...args: any[]): any;
+    static pad(number: any, idx?: number): string;
+    bits(value: any): Bitmask;
+}
+export declare const pad: typeof Date.pad;

--- a/src/decade.d.ts
+++ b/src/decade.d.ts
@@ -1,0 +1,13 @@
+import { ExtDateTime } from './interface.js';
+export declare class Decade extends ExtDateTime {
+    constructor(input: any);
+    get decade(): any;
+    set decade(decade: any);
+    get year(): number;
+    set year(year: number);
+    get values(): any;
+    get min(): number;
+    get max(): number;
+    toEDTF(): string;
+    static pad(number: any): string;
+}

--- a/src/edtf.d.ts
+++ b/src/edtf.d.ts
@@ -1,0 +1,3 @@
+import * as types from './types.js';
+import { Constraints, ParserResult } from './parser.js';
+export declare function edtf(...args: [string | number | ParserResult] | [string, Partial<Constraints>]): types.Year | types.Date | types.Decade | types.Season | types.Interval | types.List | types.Century;

--- a/src/format.d.ts
+++ b/src/format.d.ts
@@ -1,0 +1,5 @@
+export declare function getFormat(date: any, locale: any, options: any): any;
+export declare function format(date: any, locale?: string, options?: {}): any;
+export declare namespace format {
+    var cache: Map<any, any>;
+}

--- a/src/grammar.d.ts
+++ b/src/grammar.d.ts
@@ -1,0 +1,38 @@
+declare function id(x: any): any;
+import { join } from './util.js';
+declare const _default: {
+    Lexer: any;
+    ParserRules: ({
+        name: string;
+        symbols: {
+            literal: string;
+        }[];
+        postprocess?: undefined;
+    } | {
+        name: string;
+        symbols: string[];
+        postprocess?: undefined;
+    } | {
+        name: string;
+        symbols: (string | {
+            literal: string;
+        })[];
+        postprocess: (data: any, _: any, reject: any) => any;
+    } | {
+        name: string;
+        symbols: RegExp[];
+        postprocess: typeof id;
+    } | {
+        name: string;
+        symbols: (string | RegExp)[];
+        postprocess: typeof join;
+    } | {
+        name: string;
+        symbols: (RegExp | {
+            literal: string;
+        })[];
+        postprocess: typeof join;
+    })[];
+    ParserStart: string;
+};
+export default _default;

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -1,0 +1,28 @@
+import { ParserResult } from './parser.js';
+import { EDTFType } from './types.js';
+export declare abstract class ExtDateTime {
+    abstract values: number[];
+    constructor(input: number | string | ExtDateTime | Partial<ParserResult> | undefined);
+    static get type(): EDTFType;
+    static parse(input: string): ParserResult;
+    static from(input: ExtDateTime | string): any;
+    static UTC(...args: Parameters<typeof Date.UTC>): number;
+    get type(): any;
+    get edtf(): string;
+    get isEDTF(): boolean;
+    abstract toEDTF(): string;
+    toJSON(): string;
+    toString(): string;
+    toLocaleString(...args: any[]): any;
+    inspect(): string;
+    abstract min: number;
+    abstract max: number;
+    valueOf(): number;
+    [Symbol.toPrimitive](hint: string): string | number;
+    covers(other: this): boolean;
+    compare(other: this): 0 | 1 | -1;
+    includes(other: this): boolean;
+    until(then: this): Generator<this, void, unknown>;
+    through(then: this): Generator<this, void, unknown>;
+    between(then: this): Generator<this, void, unknown>;
+}

--- a/src/interval.d.ts
+++ b/src/interval.d.ts
@@ -1,0 +1,14 @@
+import { ExtDateTime } from './interface.js';
+export declare class Interval extends ExtDateTime {
+    constructor(...args: any[]);
+    get lower(): any;
+    set lower(value: any);
+    get upper(): any;
+    set upper(value: any);
+    get finite(): boolean;
+    [Symbol.iterator](): Generator<any, void, any>;
+    get values(): any;
+    get min(): any;
+    get max(): any;
+    toEDTF(): any;
+}

--- a/src/list.d.ts
+++ b/src/list.d.ts
@@ -1,0 +1,18 @@
+import { ExtDateTime } from './interface.js';
+export declare class List extends ExtDateTime {
+    constructor(...args: any[]);
+    get values(): any;
+    get length(): any;
+    get empty(): boolean;
+    get first(): any;
+    get last(): any;
+    clear(): this;
+    concat(...args: any[]): this;
+    push(value: any): any;
+    [Symbol.iterator](): Generator<any, void, any>;
+    get min(): any;
+    get max(): any;
+    content(): any;
+    toEDTF(): string;
+    wrap(content: any): string;
+}

--- a/src/mixin.d.ts
+++ b/src/mixin.d.ts
@@ -1,0 +1,1 @@
+export declare function mixin(target: any, ...mixins: any[]): any;

--- a/src/parser.d.ts
+++ b/src/parser.d.ts
@@ -1,0 +1,19 @@
+import nearley from 'nearley';
+import type { EDTFType } from './types';
+export interface Constraints {
+    level: 0 | 1 | 2;
+    types: EDTFType[];
+    seasonIntervals: boolean;
+}
+export interface ParserResult {
+    level: 0 | 1 | 2;
+    type: EDTFType;
+    values: number[];
+    uncertain?: number;
+    approximate?: number;
+    unspecified?: number;
+    significant?: number;
+}
+export declare const defaults: Constraints;
+export declare function parse(input: string, constraints?: Partial<Constraints>): ParserResult;
+export declare function parser(): nearley.Parser;

--- a/src/sample.d.ts
+++ b/src/sample.d.ts
@@ -1,0 +1,2 @@
+export declare function sample({ count, level, type }?: {}): Generator<string, void, unknown>;
+export declare function gen(root?: string): string;

--- a/src/season.d.ts
+++ b/src/season.d.ts
@@ -1,0 +1,14 @@
+import { ExtDateTime } from './interface.js';
+export declare class Season extends ExtDateTime {
+    constructor(input: any);
+    get year(): any;
+    set year(year: any);
+    get season(): any;
+    set season(season: any);
+    get values(): any;
+    next(k?: number): Season;
+    prev(k?: number): Season;
+    get min(): number;
+    get max(): number;
+    toEDTF(): string;
+}

--- a/src/set.d.ts
+++ b/src/set.d.ts
@@ -1,0 +1,6 @@
+import { List } from './list.js';
+export declare class Set extends List {
+    static parse(input: any): import("./parser.js").ParserResult;
+    get type(): string;
+    wrap(content: any): string;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,10 @@
+export { Date } from './date.js';
+export { Year } from './year.js';
+export { Decade } from './decade.js';
+export { Century } from './century.js';
+export { Season } from './season.js';
+export { Interval } from './interval.js';
+export { List } from './list.js';
+export { Set } from './set.js';
+export type EDTFLevel0Type = 'Date' | 'Year' | 'Decade' | 'Century' | 'Interval';
+export type EDTFType = EDTFLevel0Type | 'Season' | 'List' | 'Set';

--- a/src/util.d.ts
+++ b/src/util.d.ts
@@ -1,0 +1,39 @@
+export declare function num(data: number | string | string[]): number;
+export declare function join(data: any[]): string;
+export declare function zero(): number;
+export declare function nothing(): any;
+export declare function pick<T>(...args: T[]): (data: any) => any;
+export declare function pluck(...args: any[]): (data: any) => any[];
+export declare function concat<T>(data: T[], idx?: ArrayIterator<number>): T[];
+export declare function merge(...args: any[]): (data: any) => any;
+export declare function interval(level: any): (data: any) => {
+    values: any[];
+    type: string;
+    level: any;
+};
+export declare function masked(type?: string, symbol?: string): (data: any, _: any, reject: any) => any;
+export declare function date(values: any, level?: number, extra?: any): any;
+export declare function year(values: any, level?: number, extra?: any): any;
+export declare function century(value: any, level?: number): {
+    type: string;
+    level: number;
+    values: any[];
+};
+export declare function decade(value: any, level?: number): {
+    type: string;
+    level: number;
+    values: any[];
+};
+export declare function datetime(data: any): {
+    values: number[];
+    offset: any;
+    type: string;
+    level: number;
+};
+export declare function season(data: any, level?: number): {
+    type: string;
+    level: number;
+    values: number[];
+};
+export declare function list(data: any): any;
+export declare function qualify([parts]: [any], _: any, reject: any): any;

--- a/src/year.d.ts
+++ b/src/year.d.ts
@@ -1,0 +1,13 @@
+import { ExtDateTime } from './interface.js';
+import type { ParserResult } from './parser.js';
+export declare class Year extends ExtDateTime {
+    constructor(input: number | string | Year | Partial<ParserResult> | undefined);
+    get year(): number;
+    set year(year: number);
+    get significant(): number;
+    set significant(digits: number);
+    get values(): number[];
+    get min(): number;
+    get max(): number;
+    toEDTF(): string;
+}


### PR DESCRIPTION
First attempt at fixing #49.

I'm pretty decent at writing TypeScript, but I have less experience with writing TS declaration files, and I don't know the logic of this codebase well enough to add correct annotations everywhere. Therefore, in order to make this pull request, I did the following:

1. Forked the repo to [`singingwolfboy/edtf.ts`](https://github.com/singingwolfboy/edtf.ts)
2. Renamed all the `*.js` files to `*.ts`, and added the TypeScript dependency to `package.json`
3. Spent some time looking through the codebase, annotating types where I could -- including making educated guesses when I didn't entirely understand what the code was doing
4. Committed my type annotations to my fork (where they are still visible)
5. Ran `npx tsc --declaration --emitDeclarationOnly` to make TypeScript generate the declaration files for me
6. Made a new branch off of the latest code in `inukshuk/edtf.js`, added a commit with those declaration files, and made this pull request

Some important caveats:

* I have not done any testing that these declaration files get picked up correctly by developers using TypeScript. This pull request should be considered a quick "first pass" implementation, not a tested & polished final implementation.
* I have not added type annotations to _every_ file. I mostly focused on `parser.js`, `interface.js`, and `date.js`. There are plenty of `any` types in these declaration files, which can (and probably should!) be narrowed to something more specific.

If you are not interested in merging this pull request as a result of the above caveats, I completely understand. My goal is to demonstrate how we might start to add types to this codebase, in the hopes of inspiring others to complete a more robust implementation. I intend to keep my fork up on GitHub, so that others can view the TypeScript annotations in the code, and maybe fork my work and continue it to completion.